### PR TITLE
highlight today like google calendar #27

### DIFF
--- a/content_scripts/css/calendar.css
+++ b/content_scripts/css/calendar.css
@@ -60,5 +60,9 @@ div#page-content table.calendarmonth a.aalink.day {
 }
 
 .todaySpan {
-  color: #f08000;
+  color: var(--backgroundColor);
+  background-color: var(--linkColor);
+  border-radius: 15px;
+  margin-left: 2px;
+  padding: 1px 3px;
 }


### PR DESCRIPTION
日付の色を変更から、日付を青丸で囲むことにした
google calendarを参考にした
#30 の続き