### PR TITLE
fix edit mode button position for smartphone #66

### DIFF
--- a/src/css/dark_theme.css
+++ b/src/css/dark_theme.css
@@ -58,6 +58,16 @@ div#page-content a {
     transition: 0s;
 }
 
+/* バグ修正　スマホサイズの時に非表示コースリスト，編集ボタンの上部が隠れるので */
+/* 元々ロゴがあったdivを小さくする */
+header#page-header > div.col-12.pt-3.pb-3 {
+    padding-top: 0.5rem !important;
+    padding-bottom: 0.8rem !important;
+}
+#frontpage-course-list {
+    margin-top: 0.5rem;
+}
+
 /* re-layout.jsのoptimizeResponsive()で生じるズレをここで調整 */
 @media screen and (min-width: 768px) {
     #region-main-box {


### PR DESCRIPTION
## Fixed
スマホサイズにした時に非表示コースリストと編集のボタンの上部が欠けるバグ


## How
- 非表示コースリストと編集のボタンのmargin-topを設定して位置を下にずらした
- .frontpage-course-listのpaddingを調整